### PR TITLE
fix: useSelectorCreator hook type

### DIFF
--- a/src/hooks/useSelectorCreator.luau
+++ b/src/hooks/useSelectorCreator.luau
@@ -46,7 +46,7 @@ export type UseSelectorCreatorHook<State> = <Result, Args...>(
 	@param ... Arguments to pass to the selector factory
 	@return The result of the selector
 ]=]
-local function useSelectorCreator<State, Args...>(selectorFactory: (Args...) -> (state: State) -> any, ...: Args...)
+local function useSelectorCreator<Result, Args...>(selectorFactory: (Args...) -> (state: any) -> Result, ...: Args...)
 	local arguments = pack(...)
 
 	local selector = React.useMemo(function()


### PR DESCRIPTION
I'm not getting the correct return typing when using the hook like this:
```lua
local function selectIsCurrentSection(section: menu.MenuSection)
    return function(state: State)
        return state.menu.section == section
    end
end

local open = useSelectorCreator(selectIsCurrentSection, "foo")
  --> any
```
It seems that useSelector solves this by setting the state to any and using the State generic slot for the return type.
This PR also solves the type error when
```lua
local useRootSelectorCreator = ReactReflex.useSelectorCreator :: ReactReflex.UseSelectorCreatorHook<State>
```