### PR TITLE
fix: do not skip first effect run in `useSelector`

### DIFF
--- a/src/hooks/useSelector.luau
+++ b/src/hooks/useSelector.luau
@@ -39,19 +39,14 @@ export type UseSelectorHook<State> = <Result>(
 local function useSelector<T>(selector: (state: any) -> T, equalityFn: ((next: T, prev: T) -> boolean)?): T
 	local producer = useProducer()
 	local latestSelector = React.useRef(selector) :: { current: typeof(selector) }
-	local didMount = React.useRef(true)
 
 	local result, setResult = React.useState(function()
 		return selector(producer:getState())
 	end)
 
 	React.useEffect(function()
-		if didMount.current then
-			didMount.current = false
-		else
-			setResult(selector(producer:getState()))
-			latestSelector.current = selector
-		end
+		setResult(selector(producer:getState()))
+		latestSelector.current = selector
 	end, { selector })
 
 	React.useEffect(function()


### PR DESCRIPTION
Because the first effect run is skipped with a `didMount` check, a state update may occur:
1. after the component's initial render, where`result` is initialized with the current state,
2. and before creating a subscription to the store, where`result` is kept up-to-date with the new state.

This state update would effectively get skipped, and `result` will not be set to the new state set between these two points.

Remove the `didMount` check to fix this. This should not cause problems for code following good practice.